### PR TITLE
Remove break_break_infinity.js from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ If you are not planning to make something to the scale of [Incremental Unlimited
 
 * [break_infinity.js](https://github.com/Patashu/break_infinity.js) by Patashu - e9e15
 * [decimal.js](https://github.com/MikeMcl/decimal.js) by MikeMcl - e9e15
-* break_break_infinity.js(https://github.com/Patashu/break_infinity.js/blob/40c06af42d34c4962a38d73925c1835aee48a771/break_break_infinity.js) - e1.8e308
 * [logarithmica_numerus_lite.js](https://github.com/aarextiaokhiao/magna_numerus.js/blob/master/logarithmica_numerus_lite.js) by Aarex Tiaokhiao - e1.8e308
 * [confractus_numerus.js](https://github.com/aarextiaokhiao/magna_numerus.js/blob/master/confractus_numerus.js) by Aarex Tiaokhiao - ee9e15
 * [magna_numerus.js](https://github.com/aarextiaokhiao/magna_numerus.js/blob/master/magna_numerus.js) by Aarex Tiaokhiao - ?


### PR DESCRIPTION
break_break_infinity.js was ditched as a part of break_infinity/break_eternity separation and thus is not supported anymore. break_eternity has a solid superset of break_infinity API, so break_break_infinity link is super_super_redundant.

cc @Patashu